### PR TITLE
fix: Composer.json license format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Portable and performant UTF-8, Unicode and Grapheme Clusters for PHP",
     "keywords": ["utf8","utf-8","unicode","i18n","grapheme"],
     "homepage": "https://github.com/tchwork/utf8",
-    "license": "(Apache-2.0 or GPL-2.0)",
+    "license": ["Apache-2.0", "GPL-2.0"],
     "authors": [
         {
             "name": "Nicolas Grekas",


### PR DESCRIPTION
So that tools like [this](https://github.com/kalessil/production-dependencies-guard) can parse the licenses of the package.